### PR TITLE
Fix linker error in `hello` example

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -6,6 +6,7 @@
 #![no_std]
 
 extern crate panic_semihosting;
+extern crate stm32f7xx_hal;
 
 use cortex_m_semihosting::hprintln;
 use cortex_m_rt::entry;


### PR DESCRIPTION
It didn't link to the HAL or PAC, so the vector table wasn't included in
the binary. This lead to an error in the `cortex-m-rt` linker script.