### PR TITLE
Fix USART baud rate selection

### DIFF
--- a/src/serial/macros.rs
+++ b/src/serial/macros.rs
@@ -2,7 +2,7 @@
 
 macro_rules! halUsart {
     ($(
-        $USARTX:ident: ($usartX:ident, $apbXenr:ident, $usartXen:ident),
+        $USARTX:ident: ($usartX:ident, $apbXenr:ident, $usartXsel:ident, $usartXen:ident),
     )+) => {
         $(
             impl<PINS> Serial<$USARTX, PINS> {
@@ -21,7 +21,7 @@ macro_rules! halUsart {
                     //       the correct registers directly.
 
                     // Use sysclock for baudrate
-                    rcc.dckcfgr2.modify(|_, w| w.usart1sel().bits(1));
+                    rcc.dckcfgr2.modify(|_, w| w.$usartXsel().bits(1));
 
                     // Enable clock for USART
                     rcc.$apbXenr.modify(|_, w| w.$usartXen().set_bit());

--- a/src/serial/mod.rs
+++ b/src/serial/mod.rs
@@ -105,10 +105,10 @@ mod macros;
     feature = "stm32f746",
 ))]
 halUsart! {
-    USART1: (usart1, apb2enr, usart1en),
-    USART2: (usart2, apb1enr, usart2en),
-    USART3: (usart3, apb1enr, usart3en),
-    USART6: (usart6, apb2enr, usart6en),
+    USART1: (usart1, apb2enr, usart1sel, usart1en),
+    USART2: (usart2, apb1enr, usart2sel, usart2en),
+    USART3: (usart3, apb1enr, usart3sel, usart3en),
+    USART6: (usart6, apb2enr, usart6sel, usart6en),
 }
 
 impl<USART> Write for Tx<USART>


### PR DESCRIPTION
The system clock wasn't actually selected as the USART clock source,
except for USART1. This extends the macro to select the correct clock
source for all USART instances.