### PR TITLE
Add support for 16-bit words to SPI API

### DIFF
--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
 
     // Initialize SPI
     let mut spi = Spi::new(p.SPI3, (sck, miso, mosi))
-        .enable(
+        .enable::<u8>(
             &mut rcc,
             spi::ClockDivider::DIV32,
             spi::Mode {

--- a/examples/spi_16.rs
+++ b/examples/spi_16.rs
@@ -1,0 +1,61 @@
+#![no_main]
+#![no_std]
+
+
+extern crate panic_semihosting;
+
+
+use cortex_m_rt::entry;
+use stm32f7xx_hal::{
+    prelude::*,
+    device,
+    spi::{
+        self,
+        Spi,
+    },
+};
+
+
+#[entry]
+fn main() -> ! {
+    let p = device::Peripherals::take().unwrap();
+
+    let mut rcc = p.RCC.constrain();
+
+    let gpioa = p.GPIOA.split();
+    let gpioc = p.GPIOC.split();
+    let gpiod = p.GPIOD.split();
+
+    // Configure pin for button. This happens to be the pin for the USER button
+    // on the NUCLEO-F746ZG board.
+    let button = gpioc.pc13.into_floating_input();
+
+    // Prepare pins for SPI
+    let mut ncs  = gpiod.pd14.into_push_pull_output();
+    let     sck  = gpioa.pa5.into_alternate_af5();
+    let     mosi = gpioa.pa7.into_alternate_af5();
+
+    // Set NCS pin to high (disabled) initially
+    ncs.set_high().unwrap();
+
+    // Initialize SPI
+    let mut spi = Spi::new(p.SPI1, (sck, spi::NoMiso, mosi))
+        .enable::<u16>(
+            &mut rcc,
+            spi::ClockDivider::DIV32,
+            embedded_hal::spi::MODE_0,
+        );
+
+    // Use a button to control output via the Maxim Integrated MAX5214 DAC.
+    loop {
+        let data = if button.is_high().unwrap() { 0xffff } else { 0x0000 };
+
+        let word: u16 =
+            (0b01 << 14) |   // write-through mode
+            (data & 0x3fff); // data bits
+
+        ncs.set_low().unwrap();
+        spi.write(&[word.to_be()]).unwrap();
+        ncs.set_high().unwrap();
+    }
+}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -639,6 +639,19 @@ impl_instance!(
 );
 
 
+/// Placeholder for a pin when no SCK pin is required
+pub struct NoSck;
+impl<I> Sck<I> for NoSck {}
+
+/// Placeholder for a pin when no MISO pin is required
+pub struct NoMiso;
+impl<I> Miso<I> for NoMiso {}
+
+/// Placeholder for a pin when no MOSI pin is required
+pub struct NoMosi;
+impl<I> Mosi<I> for NoMosi {}
+
+
 #[derive(Debug)]
 pub enum Error {
     FrameFormat,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -827,6 +827,17 @@ impl SupportedWordSize for u8 {
     }
 }
 
+impl private::Sealed for u16 {}
+impl SupportedWordSize for u16 {
+    fn frxth() -> cr2::FRXTHW {
+        cr2::FRXTHW::QUARTER
+    }
+
+    fn ds() -> cr2::DSW {
+        cr2::DSW::EIGHTBIT
+    }
+}
+
 
 mod private {
     /// Prevents code outside of the parent module from implementing traits

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -132,7 +132,7 @@ impl<I, P> Spi<I, P, state::Disabled>
 
     /// Initialize the SPI peripheral
     pub fn enable(self, rcc: &mut Rcc, clock_divider: ClockDivider, mode: Mode)
-        -> Spi<I, P, state::Enabled>
+        -> Spi<I, P, Enabled<u8>>
     {
         let cpol = mode.polarity == Polarity::IdleHigh;
         let cpha = mode.phase == Phase::CaptureOnSecondTransition;
@@ -143,12 +143,12 @@ impl<I, P> Spi<I, P, state::Disabled>
         Spi {
             spi:    self.spi,
             pins:   self.pins,
-            _state: state::Enabled,
+            _state: Enabled(PhantomData),
         }
     }
 }
 
-impl<I, P> Spi<I, P, state::Enabled>
+impl<I, P> Spi<I, P, Enabled<u8>>
     where
         I: Instance,
         P: Pins<I>,
@@ -252,7 +252,7 @@ impl<I, P> Spi<I, P, state::Enabled>
     }
 }
 
-impl<I, P> FullDuplex<u8> for Spi<I, P, state::Enabled>
+impl<I, P> FullDuplex<u8> for Spi<I, P, Enabled<u8>>
     where
         I: Instance,
         P: Pins<I>,
@@ -268,19 +268,19 @@ impl<I, P> FullDuplex<u8> for Spi<I, P, state::Enabled>
     }
 }
 
-impl<I, P> transfer::Default<u8> for Spi<I, P, state::Enabled>
+impl<I, P> transfer::Default<u8> for Spi<I, P, Enabled<u8>>
     where
         I: Instance,
         P: Pins<I>,
 {}
 
-impl<I, P> write::Default<u8> for Spi<I, P, state::Enabled>
+impl<I, P> write::Default<u8> for Spi<I, P, Enabled<u8>>
     where
         I: Instance,
         P: Pins<I>,
 {}
 
-impl<I, P> write_iter::Default<u8> for Spi<I, P, state::Enabled>
+impl<I, P> write_iter::Default<u8> for Spi<I, P, Enabled<u8>>
     where
         I: Instance,
         P: Pins<I>,
@@ -643,7 +643,7 @@ pub struct Tx<I>(PhantomData<I>);
 /// underlying [`dma::Transfer`] instances.
 pub struct Transfer<I, P, Buffer, Rx: dma::Target, Tx: dma::Target, State> {
     buffer: Pin<Buffer>,
-    target: Spi<I, P, state::Enabled>,
+    target: Spi<I, P, Enabled<u8>>,
     rx:     dma::Transfer<Rx, dma::PtrBuffer, State>,
     tx:     dma::Transfer<Tx, dma::PtrBuffer, State>,
     _state: State,
@@ -754,7 +754,7 @@ impl<I, P, Buffer, Rx, Tx> Transfer<I, P, Buffer, Rx, Tx, dma::Started>
 pub struct TransferResources<I, P, Rx: dma::Target, Tx: dma::Target, Buffer> {
     pub rx_stream: Rx::Stream,
     pub tx_stream: Tx::Stream,
-    pub target:    Spi<I, P, state::Enabled>,
+    pub target:    Spi<I, P, Enabled<u8>>,
     pub buffer:    Pin<Buffer>,
 }
 
@@ -771,3 +771,10 @@ impl<I, P, Rx, Tx, Buffer> fmt::Debug
         write!(f, "TransferResources {{ .. }}")
     }
 }
+
+
+/// Indicates that the SPI peripheral is enabled
+///
+/// The `Word` type parameter indicates which word size the peripheral is
+/// configured for.
+pub struct Enabled<Word>(PhantomData<Word>);


### PR DESCRIPTION
This PR adds support for 16-bit words to the SPI API, except for the DMA part.