### PR TITLE
Add support for 16-bit SPI transfers via DMA

### DIFF
--- a/examples/spi_16.rs
+++ b/examples/spi_16.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
             (data & 0x3fff); // data bits
 
         ncs.set_low().unwrap();
-        spi.write(&[word.to_be()]).unwrap();
+        spi.write(&[word]).unwrap();
         ncs.set_high().unwrap();
     }
 }

--- a/examples/spi_dma_16.rs
+++ b/examples/spi_dma_16.rs
@@ -1,0 +1,113 @@
+#![no_main]
+#![no_std]
+
+
+extern crate panic_semihosting;
+
+
+use core::pin::Pin;
+
+use cortex_m::{
+    asm,
+    interrupt,
+};
+use cortex_m_rt::entry;
+use stm32f7xx_hal::{
+    prelude::*,
+    device,
+    dma::{
+        self,
+        DMA,
+    },
+    spi::{
+        self,
+        Spi,
+    },
+};
+
+
+#[entry]
+fn main() -> ! {
+    let p = device::Peripherals::take().unwrap();
+
+    let mut rcc = p.RCC.constrain();
+
+    let dma   = DMA::new(p.DMA2);
+    let gpioa = p.GPIOA.split();
+    let gpioc = p.GPIOC.split();
+    let gpiod = p.GPIOD.split();
+
+    // Configure pin for button. This happens to be the pin for the USER button
+    // on the NUCLEO-F746ZG board.
+    let button = gpioc.pc13.into_floating_input();
+
+    // Prepare pins for SPI
+    let mut ncs  = gpiod.pd14.into_push_pull_output();
+    let     sck  = gpioa.pa5.into_alternate_af5();
+    let     mosi = gpioa.pa7.into_alternate_af5();
+
+    // Prepare DMA streams
+    let mut rx_stream = dma.streams.stream0;
+    let mut tx_stream = dma.streams.stream3;
+
+    let dma = dma.handle.enable(&mut rcc);
+
+    // Set NCS pin to high (disabled) initially
+    ncs.set_high().unwrap();
+
+    // Initialize SPI
+    let mut spi = Spi::new(p.SPI1, (sck, spi::NoMiso, mosi))
+        .enable(
+            &mut rcc,
+            spi::ClockDivider::DIV32,
+            embedded_hal::spi::MODE_0,
+        );
+
+    // Create the buffer we're going to use for DMA. This is safe, as this
+    // function won't return as long as the program runs, so there's no chance
+    // of anyone else using the same static.
+    static mut BUFFER: [u16; 1] = [0; 1];
+    let mut buffer = unsafe { Pin::new(&mut BUFFER) };
+
+    // Use a button to control output via the Maxim Integrated MAX5214 DAC.
+    loop {
+        let data = if button.is_high().unwrap() { 0xffff } else { 0x0000 };
+
+        buffer[0] =
+            (0b01 << 14) |   // write-through mode
+            (data & 0x3fff); // data bits
+
+        // Prepare DMA transfer
+        let mut transfer = spi.transfer_all(
+            buffer,
+            &dma,
+            &dma,
+            rx_stream,
+            tx_stream,
+        );
+
+        // Start DMA transfer and wait for it to finish
+        ncs.set_low().unwrap();
+        let res = interrupt::free(|_| {
+            transfer.enable_interrupts(&dma, &dma, dma::Interrupts {
+                transfer_complete: true,
+                transfer_error:    true,
+                direct_mode_error: true,
+                .. dma::Interrupts::default()
+            });
+
+            let transfer = transfer.start(&dma, &dma);
+
+            asm::wfi();
+
+            transfer.wait(&dma, &dma)
+                .unwrap()
+        });
+        ncs.set_high().unwrap();
+
+        buffer    = res.buffer;
+        spi       = res.target;
+        rx_stream = res.rx_stream;
+        tx_stream = res.tx_stream;
+    }
+}

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -743,6 +743,17 @@ impl SupportedWordSize for u8 {
     }
 }
 
+impl private::Sealed for u16 {}
+impl SupportedWordSize for u16 {
+    fn msize() -> cr::MSIZEW {
+        cr::MSIZEW::HALFWORD
+    }
+
+    fn psize() -> cr::PSIZEW {
+        cr::MSIZEW::HALFWORD
+    }
+}
+
 
 mod private {
     /// Prevents code outside of the parent module from implementing traits

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -675,8 +675,8 @@ pub struct Tx<I>(PhantomData<I>);
 pub struct Transfer<I, P, Buffer, Rx: dma::Target, Tx: dma::Target, State> {
     buffer: Pin<Buffer>,
     target: Spi<I, P, Enabled<u8>>,
-    rx:     dma::Transfer<Rx, dma::PtrBuffer, State>,
-    tx:     dma::Transfer<Tx, dma::PtrBuffer, State>,
+    rx:     dma::Transfer<Rx, dma::PtrBuffer<u8>, State>,
+    tx:     dma::Transfer<Tx, dma::PtrBuffer<u8>, State>,
     _state: State,
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -830,11 +830,11 @@ impl SupportedWordSize for u8 {
 impl private::Sealed for u16 {}
 impl SupportedWordSize for u16 {
     fn frxth() -> cr2::FRXTHW {
-        cr2::FRXTHW::QUARTER
+        cr2::FRXTHW::HALF
     }
 
     fn ds() -> cr2::DSW {
-        cr2::DSW::EIGHTBIT
+        cr2::DSW::SIXTEENBIT
     }
 }
 


### PR DESCRIPTION
This pull contains the following changes:
- Fix the 16-bit SPI mode. My last pull request contained a mistake.
- Make DMA generic over word size, add 16-bit support.
- Add support for 16-bit DMA transfers to SPI module.